### PR TITLE
Install pyav deps for actions

### DIFF
--- a/py35-tox/Dockerfile
+++ b/py35-tox/Dockerfile
@@ -13,7 +13,8 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN apt-get update \
     && apt-get install -y \
-        libudev-dev \
+        libudev-dev libavformat-dev libavcodec-dev libavdevice-dev \
+        libavutil-dev libswscale-dev libswresample-dev libavfilter-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --no-cache-dir tox

--- a/py36-tox/Dockerfile
+++ b/py36-tox/Dockerfile
@@ -13,7 +13,8 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN apt-get update \
     && apt-get install -y \
-        libudev-dev \
+        libudev-dev libavformat-dev libavcodec-dev libavdevice-dev \
+        libavutil-dev libswscale-dev libswresample-dev libavfilter-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --no-cache-dir tox

--- a/py37-tox/Dockerfile
+++ b/py37-tox/Dockerfile
@@ -13,7 +13,8 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN apt-get update \
     && apt-get install -y \
-        libudev-dev \
+        libudev-dev libavformat-dev libavcodec-dev libavdevice-dev \
+        libavutil-dev libswscale-dev libswresample-dev libavfilter-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --no-cache-dir tox


### PR DESCRIPTION
This is to be able to run tests after home-assistant/home-assistant#21473 is merged.  I haven't been able to test these actions directly due to actions not running on forks, but the base image is from `stretch` which should meet requirements for the library.