### PR TITLE
Add hassfest action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # actions
+
 GitHub Actions for Home Assistant workflows
 
 ## JQ
@@ -11,3 +12,30 @@ GitHub Actions for Home Assistant workflows
 - `home-assistant/actions/py37-tox@master`
 - `home-assistant/actions/py36-tox@master`
 - `home-assistant/actions/py35-tox@master`
+
+## hassfest
+
+_Run hassfest to validate standalone integration repositories._
+
+**action**: `home-assistant/actions/hassfest@master`
+
+example implementation:
+
+```yaml
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+        - uses: "actions/checkout@v2"
+        - uses: home-assistant/actions/hassfest@master
+```
+
+This will run the `hassfest` action on every push and pull request to all branches, as well as every midnight.

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -5,6 +5,7 @@ COPY entrypoint.sh /entrypoint.sh
 RUN \
     apk add --no-cache \
         python3-dev \
+        bash \
         git \
         gcc \
         libc-dev \

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3-alpine
 
+COPY entrypoint.sh /entrypoint.sh
+
 RUN \
     apk add --no-cache \
         python3-dev \
@@ -13,9 +15,9 @@ RUN \
     \
     && git clone --depth 1 https://github.com/home-assistant/core.git /core \
     \
-    && python3 -m pip install --no-cache-dir -e /core 
-
-COPY entrypoint.sh /entrypoint.sh
+    && python3 -m pip install --no-cache-dir -e /core \
+    \
+    && chmod +x /entrypoint.sh
 
 WORKDIR "/github/workspace"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -15,9 +15,7 @@ RUN \
     \
     && git clone --depth 1 https://github.com/home-assistant/core.git /core \
     \
-    && python3 -m pip install --no-cache-dir -e /core \
-    \
-    && chmod +x /entrypoint.sh
+    && python3 -m pip install --no-cache-dir -e /core 
 
 WORKDIR "/github/workspace"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3-alpine
+
+RUN \
+    apk add --no-cache \
+        python3-dev \
+        git \
+        gcc \
+        libc-dev \
+        libffi-dev \
+        openssl-dev \
+    \
+    && rm -rf /var/cache/apk/* \
+    \
+    && git clone --depth 1 https://github.com/home-assistant/core.git /core \
+    \
+    && python3 -m pip install --no-cache-dir -e /core 
+
+COPY entrypoint.sh /entrypoint.sh
+
+WORKDIR "/github/workspace"
+ENTRYPOINT ["/entrypoint.sh"]
+
+LABEL "name"="hassfest"
+LABEL "maintainer"="Home Assistant <hello@home-assistant.io>"
+LABEL "version"="1.0"
+
+LABEL "com.github.actions.name"="hassfest"
+LABEL "com.github.actions.description"="Run hassfest to validate standalone integration repositories"
+LABEL "com.github.actions.icon"="terminal"
+LABEL "com.github.actions.color"="gray-dark"

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -15,7 +15,9 @@ RUN \
     \
     && git clone --depth 1 https://github.com/home-assistant/core.git /core \
     \
-    && python3 -m pip install --no-cache-dir -e /core 
+    && python3 -m pip install --no-cache-dir -e /core \
+    \
+    && chmod +x /entrypoint.sh
 
 WORKDIR "/github/workspace"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/hassfest/entrypoint.sh
+++ b/hassfest/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -l
+set -e
+
+for manifestfile in $(find $GITHUB_WORKSPACE -type f -name manifest.json); do
+    python3 -m script.hassfest --action validate --integration-path "$(dirname -- "$manifestfile")"
+done

--- a/hassfest/entrypoint.sh
+++ b/hassfest/entrypoint.sh
@@ -1,6 +1,16 @@
-#!/bin/sh -l
+#!/bin/bash
 set -e
 
+declare -a INTEGRATIONS
+
 for manifestfile in $(find $GITHUB_WORKSPACE -type f -name manifest.json); do
-    python3 -m script.hassfest --action validate --integration-path "$(dirname -- "$manifestfile")"
+    INTEGRATIONS+=(--integration-path)
+    INTEGRATIONS+=("$(dirname -- ${manifestfile})")
 done
+
+if [ "${INTEGRATIONS}" = "" ]; then
+    echo "No integrations found!"
+    exit 1
+fi
+echo "${INTEGRATIONS[@]}"
+python3 -m script.hassfest --action validate "${INTEGRATIONS[@]}"


### PR DESCRIPTION
Adds a hassfest action as discussed in https://github.com/home-assistant/core/pull/34277

Have tested my fork here: https://github.com/hacs/integration/runs/593085350?check_suite_focus=true#step:4:1

It fails as expected since I have a key that is not allowed in the manifest file.