### PR TITLE
Remove awesomeversion

### DIFF
--- a/hassfest/requirements.txt
+++ b/hassfest/requirements.txt
@@ -1,4 +1,3 @@
-awesomeversion==21.2.0
 pipdeptree==1.0.0
 stdlib-list==0.7.0
 tqdm==4.48.2


### PR DESCRIPTION
From the 2021.3.0 beta this is a core dependency, no need to keep it here anymore.