### PR TITLE
Replacing ./home-assistant/version.git ./${{ github.repository_owner }}/version.git, and add ability to use both SignerID or Organization for codenotary validation

### DIFF
--- a/helpers/codenotary/action.yml
+++ b/helpers/codenotary/action.yml
@@ -7,8 +7,8 @@ inputs:
   password:
     description: Password for CodeNotary login
     required: true
-  organisation:
-    description: Organisation for CodeNotary signing
+  signer:
+    description: Organisation or signerID for CodeNotary signing
     required: true
   source:
     description: Source for CodeNotary signing
@@ -22,7 +22,13 @@ runs:
 
     - shell: bash
       run: |
-        state="$(vcn authenticate --output json ${{ inputs.source }} | jq '.verification.status // 2')"
+        if [[ "$VCN_SIGNER" =~ ^0x ]]; then
+          local vcn_cli=("--signerID")
+        else
+          local vcn_cli=("--org")
+        fi
+
+        state="$(vcn authenticate "$vcn_cli" "$VCN_SIGNER" --output json ${{ inputs.source }} | jq '.verification.status // 2')"
         if [[ "${state}" == "2" ]]; then
           vcn login
           vcn notarize --public ${{ inputs.source }}
@@ -30,7 +36,7 @@ runs:
           echo "Target is already verified."
         fi
       env:
-        VCN_ORG: ${{ inputs.organisation }}
+        VCN_SIGNER: ${{ inputs.signer }}
         VCN_OTP_EMPTY: true
         VCN_USER: ${{ inputs.user }}
         VCN_PASSWORD: ${{ inputs.password }}

--- a/helpers/version-push/action.yml
+++ b/helpers/version-push/action.yml
@@ -33,7 +33,7 @@ runs:
         fi
 
     - shell: bash
-      run: git clone --depth 1 https://github.com/home-assistant/version.git /tmp/version
+      run: git clone --depth 1 https://github.com/${{ github.repository_owner }}/version.git /tmp/version
 
     - shell: bash
       run: |


### PR DESCRIPTION
I've changed the URL to the version.git to a relative path with the context variable ${{ github.repository_owner }}, in order to be able to use the helper action, also from a fork of the other components of home-assistant.