### PR TITLE
Add `release-assets` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ _A collection of GitHub Action helpers, these are considered internal to the Hom
 - [git-init](./helpers/git-init/action.yml)
 - [info](./helpers/info/action.yml)
 - [jq](./helpers/jq/action.yml)
+- [release-assets](./helpers/release-assets/action.yml)
 - [verify-version](./helpers/verify-version/action.yml)
 - [version](./helpers/version/action.yml)
 - [version-push](./helpers/version-push/action.yml)

--- a/helpers/release-assets/action.yml
+++ b/helpers/release-assets/action.yml
@@ -24,7 +24,23 @@ runs:
       run: |
         echo "::set-output name=sdist::$(ls ${{ inputs.folder }} | grep '.*.tar.gz' | tail -n 1)"
         echo "::set-output name=wheel::$(ls ${{ inputs.folder }} | grep '.*.whl' | tail -n 1)"
+    - name: Check for existing assets
+      id: existing-assets
+      shell: bash
+      run: |
+        API_REQUEST=$(curl -sS \
+          -H "Accept: application/vnd.github.v3+json" \
+          ${{ github.event.release.assets_url }})
+        FOUND_ASSETS=$(echo $API_REQUEST | jq ".[] .name")
+        printf "Found release assets:\n$FOUND_ASSETS\n"
+        if [[ $FOUND_ASSETS == *"${{ steps.file-names.outputs.sdist }}"* ]]; then
+          echo "::set-output name=sdist-found::true"
+        fi
+        if [[ $FOUND_ASSETS == *"${{ steps.file-names.outputs.wheel }}"* ]]; then
+          echo "::set-output name=wheel-found::true"
+        fi
     - name: Upload release asset (sdist)
+      if: ${{ !steps.existing-assets.outputs.sdist-found }}
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
@@ -34,6 +50,7 @@ runs:
         asset_name: ${{ steps.file-names.outputs.sdist }}
         asset_content_type: application/gzip
     - name: Upload release asset (wheel)
+      if: ${{ !steps.existing-assets.outputs.wheel-found }}
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/helpers/release-assets/action.yml
+++ b/helpers/release-assets/action.yml
@@ -1,0 +1,44 @@
+name: 'Home Assistant helper: release-assets'
+description: 'GitHub action helper: release-assets'
+inputs:
+  github-token:
+    description: GITHUB_TOKEN with 'contents' write permission
+    required: true
+  folder:
+    description: Folder for distribution packages
+    required: false
+    default: "dist/"
+runs:
+  using: "composite"
+  steps:
+    - name: Fail if not release event
+      if: github.event_name != 'release'
+      shell: bash
+      run: |
+        echo "Action can only be run for 'release' events"
+        echo "Current event_name: ${{ github.event_name }}"
+        exit 1
+    - name: Get build file names
+      id: file-names
+      shell: bash
+      run: |
+        echo "::set-output name=sdist::$(ls ${{ inputs.folder }} | grep '.*.tar.gz' | tail -n 1)"
+        echo "::set-output name=wheel::$(ls ${{ inputs.folder }} | grep '.*.whl' | tail -n 1)"
+    - name: Upload release asset (sdist)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{ inputs.folder }}${{ steps.file-names.outputs.sdist }}
+        asset_name: ${{ steps.file-names.outputs.sdist }}
+        asset_content_type: application/gzip
+    - name: Upload release asset (wheel)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{ inputs.folder}}${{ steps.file-names.outputs.wheel }}
+        asset_name: ${{ steps.file-names.outputs.wheel }}
+        asset_content_type: application/zip


### PR DESCRIPTION
Helper action to upload `sdists` and `wheels` as release assets.
Could be used for https://github.com/home-assistant/frontend/pull/11566 and eventually Core.