### PR TITLE
Remove deprecated set-output command

### DIFF
--- a/helpers/find-addons/action.yml
+++ b/helpers/find-addons/action.yml
@@ -25,5 +25,5 @@ runs:
 
         echo "Found addons: ${addons[@]}"
         echo "Found addons (JSON): [${json_list}]"
-        echo "::set-output name=addons::${addons[@]}"
-        echo "::set-output name=addons_list::[${json_list}]"
+        echo "addons=${addons[@]}" >> "$GITHUB_OUTPUT"
+        echo "addons_list=[${json_list}]" >> "$GITHUB_OUTPUT"

--- a/helpers/info/action.yml
+++ b/helpers/info/action.yml
@@ -51,6 +51,6 @@ runs:
         echo "Image: $image"
         echo "Version: $version"
 
-        echo "::set-output name=architectures::$archs"
-        echo "::set-output name=image::$image"
-        echo "::set-output name=version::$version"
+        echo "architectures=$archs" >> "$GITHUB_OUTPUT"
+        echo "image=$image" >> "$GITHUB_OUTPUT"
+        echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/helpers/version-push/action.yml
+++ b/helpers/version-push/action.yml
@@ -27,9 +27,9 @@ runs:
           exit 1
         fi
         if [[ -z "${{ inputs.key-description }}" ]];then
-          echo "::set-output name=key-description::${{ inputs.key }}"
+          echo "key-description=${{ inputs.key }}" >> "$GITHUB_OUTPUT"
         else
-          echo "::set-output name=key-description::${{ inputs.key-description }}"
+          echo "key-description=${{ inputs.key-description }}" >> "$GITHUB_OUTPUT"
         fi
 
     - shell: bash

--- a/helpers/version/action.yml
+++ b/helpers/version/action.yml
@@ -62,8 +62,8 @@ runs:
           stable="false"
         fi
 
-        echo "::set-output name=stable::$stable"
-        echo "::set-output name=version::$version"
+        echo "stable=$stable" >> "$GITHUB_OUTPUT"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
 
     - shell: bash
       run: |
@@ -75,22 +75,22 @@ runs:
       id: channel
       run: |
         if [[ ! -z "${{ github.event.inputs.channel }}" ]]; then
-          echo "::set-output name=channel::${{ github.event.inputs.channel }}"
+          echo "channel=${{ github.event.inputs.channel }}" >> "$GITHUB_OUTPUT"
 
         elif [[ "${{ inputs.type }}" =~ (plugin|supervisor) ]]; then
           if [[ "${{ steps.version.outputs.stable }}" == "true" ]]; then
-            echo "::set-output name=channel::beta"
+            echo "channel=beta" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=channel::dev"
+            echo "channel=dev" >> "$GITHUB_OUTPUT"
           fi
 
         elif [[ "${{ inputs.type }}" == "core" ]]; then
           if [[ "${{ steps.version.outputs.version }}" =~ dev ]]; then
-            echo "::set-output name=channel::dev"
+            echo "channel=dev" >> "$GITHUB_OUTPUT"
           elif [[ "${{ steps.version.outputs.version }}" =~ b ]]; then
-            echo "::set-output name=channel::beta"
+            echo "channel=beta" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=channel::stable"
+            echo "channel=stable" >> "$GITHUB_OUTPUT"
           fi
         fi
 
@@ -98,21 +98,21 @@ runs:
       id: publish
       run: |
         if [[ ! -z "${{ github.event.inputs.publish }}" ]]; then
-            echo "::set-output name=publish::${{ github.event.inputs.publish }}"
+            echo "publish=${{ github.event.inputs.publish }}" >> "$GITHUB_OUTPUT"
 
         elif [[ "${{ inputs.type }}" =~ (plugin|supervisor) ]]; then
           if [[ ! -z "${{ github.head_ref }}" ]]; then
-            echo "::set-output name=publish::false"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" =~ (release|push) ]]; then
-            echo "::set-output name=publish::true"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=publish::false"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
 
         elif [[ "${{ inputs.type }}" == "core" ]]; then
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "::set-output name=publish::true"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=publish::false"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
         fi


### PR DESCRIPTION
GitHub actions complain:
The `set-output` command is deprecated and will be disabled soon.

Migrate to the new syntax using environment variables.

Fixes: #76