### PR TITLE
Only replace `SUPERVISOR_VERSION` const

### DIFF
--- a/helpers/version/action.yml
+++ b/helpers/version/action.yml
@@ -68,7 +68,7 @@ runs:
     - shell: bash
       run: |
         if [[ "${{ inputs.type }}" == "supervisor" ]]; then
-          sed -i "s/SUPERVISOR_VERSION .*/SUPERVISOR_VERSION = \"${{ steps.version.outputs.version }}\"/g" supervisor/const.py
+          sed -i "s/^SUPERVISOR_VERSION .*/SUPERVISOR_VERSION = \"${{ steps.version.outputs.version }}\"/g" supervisor/const.py
         fi
 
     - shell: bash

--- a/helpers/version/action.yml
+++ b/helpers/version/action.yml
@@ -68,7 +68,7 @@ runs:
     - shell: bash
       run: |
         if [[ "${{ inputs.type }}" == "supervisor" ]]; then
-          sed -i "s/^SUPERVISOR_VERSION .*/SUPERVISOR_VERSION = \"${{ steps.version.outputs.version }}\"/g" supervisor/const.py
+          sed -i "s/^SUPERVISOR_VERSION =.*/SUPERVISOR_VERSION = \"${{ steps.version.outputs.version }}\"/g" supervisor/const.py
         fi
 
     - shell: bash


### PR DESCRIPTION
Fixes: https://github.com/home-assistant/supervisor/issues/4069

sed accidentally replaces the value of `ATTR_SUPERVISOR_VERSION`. Should only set the value of the exact `SUPERVISOR_VERSION` constant.