### PR TITLE
Add reusable stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -17,8 +17,16 @@ on:
         default: 7
         required: false
         type: number
-
-  workflow_dispatch:
+      exempt-issue-labels:
+        description: "Labels on issues exempted from stale"
+        default: "pinned,no-stale,help-wanted,rfc,security"
+        required: false
+        type: string
+      exempt-pr-labels:
+        description: "Labels on PRs exempted from stale"
+        default: "pinned,no-stale,rfc,security"
+        required: false
+        type: string
 
 jobs:
   stale:
@@ -36,7 +44,7 @@ jobs:
           days-before-close: ${{ inputs.days-before-close }}
           remove-stale-when-updated: true
           stale-issue-label: "stale"
-          exempt-issue-labels: "pinned,no-stale,help-wanted,rfc,security"
+          exempt-issue-labels: ${{ inputs.exempt-issue-labels }}
           stale-issue-message: >
             There hasn't been any activity on this issue recently, so we
             clean up some of the older and inactive issues.
@@ -48,7 +56,7 @@ jobs:
             This issue has now been marked as stale and will be closed if no
             further activity occurs. Thank you for your contributions.
           stale-pr-label: "stale"
-          exempt-pr-labels: "pinned,no-stale,rfc,security"
+          exempt-pr-labels: ${{ inputs.exempt-pr-labels }}
           stale-pr-message: >
             There hasn't been any activity on this pull request recently. This
             pull request has been automatically marked as stale because of that

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -17,14 +17,12 @@ on:
         default: 7
         required: false
         type: number
-      exempt-issue-labels:
+      additional-exempt-issue-labels:
         description: "Labels on issues exempted from stale"
-        default: "pinned,no-stale,help-wanted,rfc,security"
         required: false
         type: string
-      exempt-pr-labels:
+      additional-exempt-pr-labels:
         description: "Labels on PRs exempted from stale"
-        default: "pinned,no-stale,rfc,security"
         required: false
         type: string
 
@@ -44,7 +42,7 @@ jobs:
           days-before-close: ${{ inputs.days-before-close }}
           remove-stale-when-updated: true
           stale-issue-label: "stale"
-          exempt-issue-labels: ${{ inputs.exempt-issue-labels }}
+          exempt-issue-labels: "pinned,no-stale,help-wanted,rfc,security,${{ inputs.additional-exempt-issue-labels }}"
           stale-issue-message: >
             There hasn't been any activity on this issue recently, so we
             clean up some of the older and inactive issues.
@@ -56,7 +54,7 @@ jobs:
             This issue has now been marked as stale and will be closed if no
             further activity occurs. Thank you for your contributions.
           stale-pr-label: "stale"
-          exempt-pr-labels: ${{ inputs.exempt-pr-labels }}
+          exempt-pr-labels: "pinned,no-stale,rfc,security,${{ inputs.additional-exempt-pr-labels }}"
           stale-pr-message: >
             There hasn't been any activity on this pull request recently. This
             pull request has been automatically marked as stale because of that

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,7 +14,7 @@ on:
         type: number
       days-before-close:
         description: "Idle number of days before closing stale issues/PRs"
-        default: 30
+        default: 7
         required: false
         type: number
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,8 +3,6 @@ name: Stale
 
 # yamllint disable-line rule:truthy
 on:
-  schedule:
-    - cron: "0 6 * * *"
   workflow_call:
     inputs:
       days-before-stale:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -40,7 +40,9 @@ jobs:
           days-before-close: ${{ inputs.days-before-close }}
           remove-stale-when-updated: true
           stale-issue-label: "stale"
-          exempt-issue-labels: "pinned,no-stale,help-wanted,rfc,security,${{ inputs.additional-exempt-issue-labels }}"
+          exempt-issue-labels: >-
+            pinned,no-stale,help-wanted,rfc,security,
+            ${{ inputs.additional-exempt-issue-labels }}
           stale-issue-message: >
             There hasn't been any activity on this issue recently, so we
             clean up some of the older and inactive issues.
@@ -52,7 +54,9 @@ jobs:
             This issue has now been marked as stale and will be closed if no
             further activity occurs. Thank you for your contributions.
           stale-pr-label: "stale"
-          exempt-pr-labels: "pinned,no-stale,rfc,security,${{ inputs.additional-exempt-pr-labels }}"
+          exempt-pr-labels: >-
+            pinned,no-stale,rfc,security,
+            ${{ inputs.additional-exempt-pr-labels }}
           stale-pr-message: >
             There hasn't been any activity on this pull request recently. This
             pull request has been automatically marked as stale because of that

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -25,7 +25,6 @@ jobs:
     name: 🧹 Clean up stale issues and PRs
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # only for delete-branch option
       issues: write
       pull-requests: write
     steps:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,46 @@
+---
+name: Stale
+
+# yamllint disable-line rule:truthy
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: 🧹 Clean up stale issues and PRs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # only for delete-branch option
+      issues: write
+      pull-requests: write
+    steps:
+      - name: 🚀 Run stale
+        uses: actions/stale@v8.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 7
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          exempt-issue-labels: "pinned,no-stale,help-wanted,rfc,security"
+          stale-issue-message: >
+            There hasn't been any activity on this issue recently, so we
+            clean up some of the older and inactive issues.
+
+            Please make sure to update to the latest version and
+            check if that solves the issue. Let us know if that works for you
+            by leaving a comment 👍
+
+            This issue has now been marked as stale and will be closed if no
+            further activity occurs. Thank you for your contributions.
+          stale-pr-label: "stale"
+          exempt-pr-labels: "pinned,no-stale,rfc,security"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request recently. This
+            pull request has been automatically marked as stale because of that
+            and will be closed if no further activity occurs within 7 days.
+
+            Thank you for your contributions.

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,6 +6,18 @@ on:
   schedule:
     - cron: "0 6 * * *"
   workflow_call:
+    inputs:
+      days-before-stale:
+        description: "Idle number of days before marking issues/PRs stale"
+        default: 30
+        required: false
+        type: number
+      days-before-close:
+        description: "Idle number of days before closing stale issues/PRs"
+        default: 30
+        required: false
+        type: number
+
   workflow_dispatch:
 
 jobs:
@@ -21,8 +33,8 @@ jobs:
         uses: actions/stale@v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 30
-          days-before-close: 7
+          days-before-stale: ${{ inputs.days-before-stale }}
+          days-before-close: ${{ inputs.days-before-close }}
           remove-stale-when-updated: true
           stale-issue-label: "stale"
           exempt-issue-labels: "pinned,no-stale,help-wanted,rfc,security"


### PR DESCRIPTION
Add a stale GitHub action workflow which we can reuase in other repositories. This is meant as a non-mandatory default configuration.

It can be reused using the `uses` syntax in a job configuration, e.g.

```yaml
---
name: Stale

on:
  schedule:
    - cron: "0 6 * * *"
  workflow_dispatch:

jobs:
  workflows:
    uses: home-assistant/actions/.github/workflows/stale.yaml@master
```