### PR TITLE
Ensure Supevisor/Plug-ins dev versions are higher than the last release

### DIFF
--- a/helpers/version/action.yml
+++ b/helpers/version/action.yml
@@ -39,10 +39,16 @@ runs:
         elif [[ "${version}" =~ (master|main) && "${{ inputs.type }}" =~ (supervisor|plugin|generic) ]]; then
           today="$(date --utc '+%Y-%m-%d')"
           midnight_timestamp="$(date --utc +%s --date=$today)"
-          calver_date="$(date --utc --date=$today '+%Y.%m.dev%d')"
+          calver_date="$(date --utc --date=$today '+%Y.%m')"
+          if tag=$(git describe --tags --abbrev=0 --match="${calver_date}.*" 2>/dev/null)
+          then
+            base_ver="$(echo $tag | awk -F. '{printf "%s.%s.%d",$1,$2,$3+1}')"
+          else
+            base_ver="${calver_date}.0"
+          fi
           commit_count="$(git rev-list --count --since=$midnight_timestamp HEAD)"
-          commit_count="$(printf "%02d" ${commit_count})"
-          version="${calver_date}${commit_count}"
+          calver_dev="$(date --utc --date=$today '+.dev%d')$(printf "%02d" ${commit_count})"
+          version="${base_ver}${calver_dev}"
 
         elif [[ "${version}" == "merge" && "${{ inputs.type }}" =~ (supervisor|plugin|generic) ]]; then
           version="${{ github.sha }}"


### PR DESCRIPTION
Currently the dev version might be considered older than the current release (by conventional versioning, where a dev appendix is considered the dev version of an upcoming release of the same version number): 2023.07.0 > 2023.07.dev2001

However, that is not our intention after we release a Supervisor or Plug-in at a given month: Subsequent dev builds from the same month should be considered newer.

Change the dev versioning to include the patch version, and increment the patch version to make sure that the latest dev release is always considered higher than the last actual release. With this change if Supervisors current release is 2023.07.1, we would generate the following dev version:
2023.07.0 < 2023.07.1.dev2001

If getting the last release fails, we fall back to the previous scheme, but we do add teh patch version. So all dev version numbers now do include the patch part by default (e.g. 2023.08.0.dev0100).