### PR TITLE
Add optional create-pr argument to version-push action

### DIFF
--- a/helpers/version-push/action.yml
+++ b/helpers/version-push/action.yml
@@ -11,11 +11,13 @@ inputs:
   version:
     required: true
     default: ''
+    description: "Version to bump to."
   channel:
     default: 'dev'
+    description: "Target channel."
 runs:
   using: "composite"
-  steps: 
+  steps:
     - shell: bash
       id: validate-input
       env:

--- a/helpers/version-push/action.yml
+++ b/helpers/version-push/action.yml
@@ -15,6 +15,10 @@ inputs:
   channel:
     default: 'dev'
     description: "Target channel."
+  create-pr:
+    default: 'false'
+    required: false
+    description: "Create pull request instead of pushing directly to the default branch."
 runs:
   using: "composite"
   steps:
@@ -54,10 +58,22 @@ runs:
     - shell: bash
       env:
         INPUTS_VERSION: ${{ inputs.version }}
+      if: ${{ inputs.create-pr != 'true' }}
       run: |
         cd /tmp/version
         git commit -am "Bump ${{ steps.validate-input.outputs.key-description }} to $INPUTS_VERSION"
         git push
+
+    - uses: peter-evans/create-pull-request@v5
+      if: ${{ inputs.create-pr == 'true' }}
+      with:
+        commit-message: "Bump ${{ steps.validate-input.outputs.key-description }} to ${{ inputs.version }}"
+        branch: "bump-${{ inputs.key }}-to-${{ inputs.version }}"
+        base: master
+        title: "Bump ${{ steps.validate-input.outputs.key-description }} to ${{ inputs.version }}"
+        body: |
+          Merging this pull request will trigger deployment of ${{ steps.validate-input.outputs.key-description }}
+          to the ${{ inputs.channel }} channel.
 
     - shell: bash
       run: rm -rf /tmp/version


### PR DESCRIPTION
We don't always want to publish system or its components right after the CI pipeline finishes. Since this is can be easily controlled by postponing the bump in the version repository, add optional argument to create a PR in the version repo instead of the direct push. Behavior for old actions not using this argument stays the same.