### PR TITLE
Add Ruff (instead of Black)

### DIFF
--- a/hassfest/requirements.txt
+++ b/hassfest/requirements.txt
@@ -2,3 +2,4 @@ black==22.8.0
 pipdeptree==1.0.0
 stdlib-list==0.7.0
 tqdm==4.48.2
+ruff==0.1.6

--- a/hassfest/requirements.txt
+++ b/hassfest/requirements.txt
@@ -1,4 +1,3 @@
-black==22.8.0
 pipdeptree==1.0.0
 stdlib-list==0.7.0
 tqdm==4.48.2


### PR DESCRIPTION
CI Action Hassfest seems to be failing because Home-Assistant is moving to Ruff instead of Black, 

https://github.com/home-assistant/core/pull/102893