### PR TITLE
Add helpers/stale-issues as an action

### DIFF
--- a/helpers/lock-issues/action.yml
+++ b/helpers/lock-issues/action.yml
@@ -1,4 +1,4 @@
-name: "Home Assitant helper: Lock old issues/PRs"
+name: "Home Assistant helper: Lock old issues/PRs"
 description: "Github action helper: Lock old issues/PRs"
 
 inputs:

--- a/helpers/stale-issues/action.yml
+++ b/helpers/stale-issues/action.yml
@@ -1,0 +1,54 @@
+name: "Home Assistant helper: Mark and close stale issues/PRs"
+description: "Github action helper: Mark and close stale issues/PRs"
+
+inputs:
+  days-before-stale:
+    description: "Idle number of days before marking issues/PRs stale"
+    default: "30"
+    required: false
+  days-before-close:
+    description: "Idle number of days before closing stale issues/PRs"
+    default: "7"
+    required: false
+  additional-exempt-issue-labels:
+    description: "Labels on issues exempted from stale"
+    required: false
+  additional-exempt-pr-labels:
+    description: "Labels on PRs exempted from stale"
+    required: false
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: 🚀 Run stale
+      uses: actions/stale@v9.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: ${{ inputs.days-before-stale }}
+        days-before-close: ${{ inputs.days-before-close }}
+        remove-stale-when-updated: true
+        stale-issue-label: "stale"
+        exempt-issue-labels: >-
+          pinned,no-stale,help-wanted,rfc,security,
+          ${{ inputs.additional-exempt-issue-labels }}
+        stale-issue-message: >
+          There hasn't been any activity on this issue recently, so we
+          clean up some of the older and inactive issues.
+
+          Please make sure to update to the latest version and
+          check if that solves the issue. Let us know if that works for you
+          by leaving a comment 👍
+
+          This issue has now been marked as stale and will be closed if no
+          further activity occurs. Thank you for your contributions.
+        stale-pr-label: "stale"
+        exempt-pr-labels: >-
+          pinned,no-stale,rfc,security,
+          ${{ inputs.additional-exempt-pr-labels }}
+        stale-pr-message: >
+          There hasn't been any activity on this pull request recently. This
+          pull request has been automatically marked as stale because of that
+          and will be closed if no further activity occurs within 7 days.
+
+          Thank you for your contributions.


### PR DESCRIPTION
There's currently a reusable workflow for marking issues as stale. This adds a reusable action, which allows for running the task along other helpers (e.g. most likely helpers/lock-issues) on the same runner and with a bit more flexibility than what can be achieved with the workflow. The inputs and steps stay the same as in the workflow.