### PR TITLE
Replace pip by uv

### DIFF
--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -3,7 +3,8 @@ FROM ghcr.io/home-assistant/home-assistant:beta
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt .
 
-RUN pip3 install -r requirements.txt
+ENV UV_SYSTEM_PYTHON=true
+RUN pip3 install uv && uv pip install -r requirements.txt
 
 WORKDIR "/github/workspace"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/home-assistant/home-assistant:beta
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt .
 
-RUN uv pip -v install -r requirements.txt
+RUN uv pip -vv install -r requirements.txt
 
 WORKDIR "/github/workspace"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -3,8 +3,7 @@ FROM ghcr.io/home-assistant/home-assistant:beta
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt .
 
-ENV UV_SYSTEM_PYTHON=true
-RUN pip3 install uv && uv pip install -r requirements.txt
+RUN uv pip install -r requirements.txt
 
 WORKDIR "/github/workspace"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -3,6 +3,7 @@ FROM ghcr.io/home-assistant/home-assistant:beta
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt .
 
+RUN pip3 install uv==0.1.27
 RUN uv pip -vv install -r requirements.txt
 
 WORKDIR "/github/workspace"

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/home-assistant/home-assistant:beta
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt .
 
-RUN uv pip install -r requirements.txt
+RUN uv pip -v install -r requirements.txt
 
 WORKDIR "/github/workspace"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/home-assistant/home-assistant:beta
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt .
 
-RUN pip3 install uv==0.1.27
+RUN pip3 install uv==0.1.28
 RUN uv pip -vv install -r requirements.txt
 
 WORKDIR "/github/workspace"

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -3,8 +3,7 @@ FROM ghcr.io/home-assistant/home-assistant:beta
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt .
 
-RUN pip3 install uv==0.1.28
-RUN uv pip -vv install -r requirements.txt
+RUN uv pip install -r requirements.txt
 
 WORKDIR "/github/workspace"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/hassfest/requirements.txt
+++ b/hassfest/requirements.txt
@@ -1,4 +1,4 @@
-pipdeptree==2.15.1
+pipdeptree==2.16.1
 stdlib-list==0.10.0
 tqdm==4.66.2
-ruff==0.2.1
+ruff==0.3.4

--- a/helpers/verify-version/action.yml
+++ b/helpers/verify-version/action.yml
@@ -18,8 +18,10 @@ runs:
         INPUTS_IGNORE_MASTER: ${{ inputs.ignore-master }}
         ACTION_PATH: ${{ github.action_path }}
         REF: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+        UV_SYSTEM_PYTHON: "true"
       run: |
-        pip install tomli
+        pip install uv
+        uv pip install tomli
         setup_version="$(python3 $ACTION_PATH/../read_version.py)"
         branch_version=$(echo "$REF" | awk -F"/" '{print $NF}' )
 

--- a/helpers/version/action.yml
+++ b/helpers/version/action.yml
@@ -38,6 +38,7 @@ runs:
         INPUTS_TYPE: ${{ inputs.type }}
         EVENT_NAME: ${{ github.event_name }}
         REF: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+        UV_SYSTEM_PYTHON: "true"
       run: |
         version=$(echo "$REF" | awk -F"/" '{print $NF}' )
 
@@ -67,8 +68,9 @@ runs:
           version="${{ github.sha }}"
 
         elif [[ "${version}" == "dev" && "$INPUTS_TYPE" == "core" ]]; then
-          python3 -m pip install packaging tomli
-          python3 -m pip install .
+          python3 -m pip install uv
+          uv pip install packaging tomli
+          uv pip install .
           python3 script/version_bump.py nightly
           version="$(python3 ${{ github.action_path }}/../read_version.py)"
         fi


### PR DESCRIPTION
We need to wait for the HA 2024.4.0b0 as it's the first image with uv already installed.

Did also upgrade the requirements to use the same versions as in core.