### PR TITLE
Add workflow to build image

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,0 +1,79 @@
+name: Build images
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which core version should be used as base image
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  HASSFEST_IMAGE_NAME: ${{ github.repository }}/hassfest
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ github.event.inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.inputs.version }}
+            type=raw,value=latest
+
+      - name: Build Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          build-args: FROM_VERSION=${{ version }}
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # todo test with core
+      - name: Checkout core repository
+        uses: actions/checkout@v4
+        with:
+          name: home-assistant/core
+          path: tmp/core
+
+      - name: Run hassfest againt core
+        run: docker run --rm -v ${{ github.workspace }}/tmp/core://github/workspace ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+
+      - name: Push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          build-args: FROM_VERSION=${{ version }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
         with:
-          context: .
+          context: ./hassfest
           build-args: FROM_VERSION=${{ version }}
           load: true
           tags: ${{ env.HASSFEST_IMAGE_TAG }}
@@ -54,7 +54,7 @@ jobs:
         id: push
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
         with:
-          context: .
+          context: ./hassfest
           build-args: FROM_VERSION=${{ version }}
           push: true
           tags: ${{ env.HASSFEST_IMAGE_TAG }}

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -60,7 +60,7 @@ jobs:
           tags: ${{ env.HASSFEST_IMAGE_TAG }}
       
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1  # v1.4.2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.HASSFEST_IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -26,14 +26,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
         with:
           context: .
           build-args: FROM_VERSION=${{ version }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
         with:
           context: .
           build-args: FROM_VERSION=${{ version }}

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   HASSFEST_IMAGE_NAME: ${{ github.repository }}/hassfest
+  HASSFEST_IMAGE_TAG: ${{ env.HASSFEST_IMAGE_NAME }}:latest
 
 jobs:
   build-and-push-image:
@@ -31,24 +32,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ github.event.inputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.inputs.version }}
-            type=raw,value=latest
-
       - name: Build Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           build-args: FROM_VERSION=${{ version }}
           load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.HASSFEST_IMAGE_TAG }}
 
       # todo test with core
       - name: Checkout core repository
@@ -58,7 +48,7 @@ jobs:
           path: tmp/core
 
       - name: Run hassfest againt core
-        run: docker run --rm -v ${{ github.workspace }}/tmp/core://github/workspace ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: docker run --rm -v ${{ github.workspace }}/tmp/core://github/workspace ${{ env.REGISTRY }}/${{ env.HASSFEST_IMAGE_TAG }}
 
       - name: Push Docker image
         id: push
@@ -67,13 +57,12 @@ jobs:
           context: .
           build-args: FROM_VERSION=${{ version }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.HASSFEST_IMAGE_TAG }}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.REGISTRY }}/${{ env.HASSFEST_IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
       

--- a/hassfest/Dockerfile
+++ b/hassfest/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/home-assistant/home-assistant:beta
+ARG FROM_VERSION=beta
+FROM ghcr.io/home-assistant/home-assistant:${FROM_VERSION}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
The hassfest action still will built their image. In a follow up PR the action will use the prebuilt one after we have implemented automatic workflow dispatching on core beta/rc/stable releases 