### PR TITLE
Don't hardcode amd64 binaries

### DIFF
--- a/helpers/info/action.yml
+++ b/helpers/info/action.yml
@@ -29,7 +29,7 @@ runs:
         version=""
 
         mkdir -p "$ACTION_PATH/bin"
-        wget -q -O "$ACTION_PATH/bin/yq" https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+        wget -q -O "$ACTION_PATH/bin/yq" "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)"
         chmod a+x "$ACTION_PATH/bin/yq"
         echo "$ACTION_PATH/bin" >> "$GITHUB_PATH"
 

--- a/helpers/info/action.yml
+++ b/helpers/info/action.yml
@@ -32,6 +32,7 @@ runs:
         wget -q -O "$ACTION_PATH/bin/yq" "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)"
         chmod a+x "$ACTION_PATH/bin/yq"
         echo "$ACTION_PATH/bin" >> "$GITHUB_PATH"
+        export PATH="$ACTION_PATH/bin:$PATH"
 
         for file_type in json yml yaml; do
           if [[ -f "$INPUTS_PATH/build.${file_type}" ]]; then


### PR DESCRIPTION
I'm trying to run the arm64 docker build on an arm64 runner for efficiency but it's not working because of this

I'm not sure of an easy way for me to test this change since it's internal to the builder action