### PR TITLE
Use preinstalled yq from runner image instead of downloading it

### DIFF
--- a/helpers/info/action.yml
+++ b/helpers/info/action.yml
@@ -28,11 +28,6 @@ runs:
         image=""
         version=""
 
-        mkdir -p "$ACTION_PATH/bin"
-        wget -q -O "$ACTION_PATH/bin/yq" https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-        chmod a+x "$ACTION_PATH/bin/yq"
-        echo "$ACTION_PATH/bin" >> "$GITHUB_PATH"
-
         for file_type in json yml yaml; do
           if [[ -f "$INPUTS_PATH/build.${file_type}" ]]; then
             archs=$(yq e -N -M '.build_from | keys' -o=json -I=0 "$INPUTS_PATH/build.${file_type}")


### PR DESCRIPTION
yq was added to Ubuntu images on July 15, 2021 in commit 5161c257 PR https://github.com/actions/runner-images/pull/3646. At this point there is probably no runner without it available anymore, so it is safe to assume it is preinstalled. Hence there is no need to download and install it manually.

Superseeds #118.