### PR TITLE
Add landingpage type to the version helper

### DIFF
--- a/helpers/version/README.md
+++ b/helpers/version/README.md
@@ -6,7 +6,7 @@ Determines **version**, **stability**, **channel**, and **publish** status for H
 
 | Input  | Required | Default   | Description                                              |
 |--------|----------|-----------|----------------------------------------------------------|
-| `type` | no       | `generic` | Target type: `core`, `supervisor`, `plugin`, or `generic` |
+| `type` | no       | `generic` | Target type: `core`, `supervisor`, `plugin`, `generic`, or `landingpage` |
 
 ## Outputs
 
@@ -49,6 +49,27 @@ These two types produce identical outputs.
 - **Push to master** generates a [CalVer](https://calver.org/) dev version: base is `YYYY.MM.N` (incrementing from the latest matching tag), suffixed with `.devDDNN` where `DD` is the UTC day and `NN` is the zero-padded commit count since UTC midnight.
 - **Stable releases** get channel `beta` (not `stable`) — this is by design for plugin/supervisor types.
 - **Note:** `supervisor` previously had a side-effect of patching `SUPERVISOR_VERSION` in `supervisor/const.py` after version resolution. This has been removed.
+
+---
+
+## Build Type: `landingpage`
+
+Used for the landingpage image, which is pushed as a tag on the existing
+`*-homeassistant` images. Version and channel resolve exactly like
+`plugin`/`supervisor`, but - like `core` - it is **only published on a release
+tag**, never on a push/merge to the default branch.
+
+| Trigger              | version                          | stable  | channel | publish |
+|----------------------|----------------------------------|---------|---------|---------|
+| **Pull Request**     | `<commit SHA>`                   | `false` | `dev`   | `false` |
+| **Push to master**   | CalVer dev `YYYY.MM.X.devDDNN`   | `false` | `dev`   | `false` |
+| **Release (tag)**    | Tag name (e.g. `2024.12.1`)     | `true`  | `beta`  | `true`  |
+| **Push to tag**      | Tag name                         | `false` | `dev`   | `false` |
+| **workflow_dispatch** | From inputs or ref              | From inputs or `false` | From inputs or computed | From inputs or `false` |
+
+### Notes
+- **Only releases are published.** Pushes (including merges to the default branch), PRs, and other events all produce `publish=false`.
+- The image is always pushed under the `landingpage` tag; the resolved `version` is only used as the image version label.
 
 ---
 
@@ -97,9 +118,9 @@ These two types produce identical outputs.
 github.event.inputs.version set?
 ├─ YES → use that value
 └─ NO
-   ├─ ref is master/main AND type is supervisor/plugin/generic?
+   ├─ ref is master/main AND type is supervisor/plugin/generic/landingpage?
    │  └─ YES → CalVer dev: YYYY.MM.X.devDDNN
-   ├─ ref is "merge" AND type is supervisor/plugin/generic?
+   ├─ ref is "merge" AND type is supervisor/plugin/generic/landingpage?
    │  └─ YES → commit SHA
    ├─ ref is "dev" AND type is core?
    │  └─ YES → nightly bump via version_bump.py
@@ -108,7 +129,7 @@ github.event.inputs.version set?
 
 ## CalVer Dev Version Format
 
-Used by `supervisor`, `plugin`, and `generic` on pushes to master/main:
+Used by `supervisor`, `plugin`, `generic`, and `landingpage` on pushes to master/main:
 
 ```
 YYYY.MM.N.devDDNN

--- a/helpers/version/action.yml
+++ b/helpers/version/action.yml
@@ -2,7 +2,7 @@ name: 'Home Assistant helper: version'
 description: 'GitHub action helper: version'
 inputs:
   type:
-    description: The type of target to check against (core, supervisor, plugin, generic)
+    description: The type of target to check against (core, supervisor, plugin, generic, landingpage)
     required: false
     default: 'generic'
 outputs:
@@ -50,7 +50,7 @@ runs:
         if [[ ! -z "$GITHUB_EVENT_INPUTS_VERSION" ]]; then
           version="$GITHUB_EVENT_INPUTS_VERSION"
 
-        elif [[ "${version}" =~ (master|main) && "$INPUTS_TYPE" =~ (supervisor|plugin|generic) ]]; then
+        elif [[ "${version}" =~ (master|main) && "$INPUTS_TYPE" =~ (supervisor|plugin|generic|landingpage) ]]; then
           today="$(date --utc '+%Y-%m-%d')"
           midnight_timestamp="$(date --utc +%s --date=$today)"
           calver_date="$(date --utc --date=$today '+%Y.%m')"
@@ -64,7 +64,7 @@ runs:
           calver_dev="$(date --utc --date=$today '+.dev%d')$(printf "%02d" ${commit_count})"
           version="${base_ver}${calver_dev}"
 
-        elif [[ "${version}" == "merge" && "$INPUTS_TYPE" =~ (supervisor|plugin|generic) ]]; then
+        elif [[ "${version}" == "merge" && "$INPUTS_TYPE" =~ (supervisor|plugin|generic|landingpage) ]]; then
           version="${{ github.sha }}"
 
         elif [[ "${version}" == "dev" && "$INPUTS_TYPE" == "core" ]]; then
@@ -95,7 +95,7 @@ runs:
         if [[ ! -z "$GITHUB_EVENT_INPUTS_CHANNEL" ]]; then
           echo "channel=$GITHUB_EVENT_INPUTS_CHANNEL" >> "$GITHUB_OUTPUT"
 
-        elif [[ "$INPUTS_TYPE" =~ (plugin|supervisor) ]]; then
+        elif [[ "$INPUTS_TYPE" =~ (plugin|supervisor|landingpage) ]]; then
           if [[ "${{ steps.version.outputs.stable }}" == "true" ]]; then
             echo "channel=beta" >> "$GITHUB_OUTPUT"
           else
@@ -132,7 +132,9 @@ runs:
             echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
 
-        elif [[ "$INPUTS_TYPE" == "core" ]]; then
+        # landingpage resolves version/channel like supervisor/plugin, but is only
+        # ever published from a release tag - never on push/merge to the default branch.
+        elif [[ "$INPUTS_TYPE" =~ (core|landingpage) ]]; then
           if [[ "$EVENT_NAME" == "release" ]]; then
             echo "publish=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
The home-assistant/landingpage repo used landingpage as the release type, however it was not set and it resulted in tagged images not being published. Add a dedicated handling and readme section for that type here.